### PR TITLE
Update php version to allow for 7.1 and remove 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "magento2-module",
     "license": "MIT",
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0",
+        "php": "~5.6.0|~7.0",
         "sitewards/setup": "1.0.0"
     },
     "autoload": {


### PR DESCRIPTION
Since Mage2 does not support 5.5 and my machine runs 7.1